### PR TITLE
[#117] Fix missing link to CPV definition

### DIFF
--- a/app/templates/network/query/index.hbs
+++ b/app/templates/network/query/index.hbs
@@ -47,7 +47,7 @@
                     <h4>Related Fields</h4>
                     <small>
                         Only procurement marked with this CPV codes will be visualised.
-                        <br/><a href="">Read more about CPV codes</a>
+                        <br/><a href="https://simap.ted.europa.eu/cpv" target="_blank">Read more about CPV codes</a>
                     </small>
                 </div>
                 <div class="col s6">


### PR DESCRIPTION
Goes to https://simap.ted.europa.eu/cpv