### PR TITLE
[#127] Stop physics after network stabilization

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,0 +1,12 @@
+{
+  "name": "elvis-ember",
+  "scripts": {},
+  "env": {},
+  "formation": {},
+  "addons": [],
+  "buildpacks": [
+    {
+      "url": "https://codon-buildpacks.s3.amazonaws.com/buildpacks/heroku/emberjs.tgz"
+    }
+  ]
+}

--- a/app/controllers/network/show.js
+++ b/app/controllers/network/show.js
@@ -132,6 +132,12 @@ export default Controller.extend({
     stabilizationIterationsDone() {
       this.showNetworkInfo();
 
+      this.get('network').setOptions({
+        'physics': {
+          'enabled': false
+        }
+      });
+
       Logger.info('stabilization iterations done');
       this.set('stabilizationPercent', 100);
       $('div#stabilization-info').fadeOut();

--- a/app/controllers/network/show.js
+++ b/app/controllers/network/show.js
@@ -130,14 +130,16 @@ export default Controller.extend({
       Logger.info('start stabilizing');
     },
     stabilizationIterationsDone() {
+      let network = this.get('network');
+      let nodesCount = network.nodesSet.length;
+
       this.showNetworkInfo();
 
-      this.get('network').setOptions({
-        'physics': {
-          'enabled': false
-        }
-      });
-
+      if (nodesCount > 150) {
+        network.setOptions({ physics: { enabled: false } });
+        Logger.info(`Network bigger than 150 nodes (${nodesCount}).`);
+        Logger.info(`Physics disabled on rendering.`);
+      }
       Logger.info('stabilization iterations done');
       this.set('stabilizationPercent', 100);
       $('div#stabilization-info').fadeOut();
@@ -148,6 +150,13 @@ export default Controller.extend({
       Logger.info(`Stabilization progress: ${amount.iterations} / ${amount.total}`);
     },
     stabilized(event) {
+      let network = this.get('network');
+      let nodesCount = network.nodesSet.length;
+      if (nodesCount > 100) {
+        network.setOptions({ physics: { enabled: false } });
+        Logger.info(`Network bigger than 100 nodes (${nodesCount}).`);
+        Logger.info(`Physics disabled after stabilizing.`);
+      }
       if (event.iterations > this.get('stIterations')) {
         let diff = event.iterations - this.get('stIterations');
         Logger.info(`Network was stabilized using ${diff} iterations more than assumed (${this.get('stIterations')})`);


### PR DESCRIPTION
Fixes #127 

- [x] Do not stop physics on small networks (< 100 nodes)
- [x] Stop physics on medium (100 to 150 nodes) networks after stabilization
- [x] Stop physics on large (> 150 nodes) networks after stabilization iterations are over (not necessarily stabilized). Also dynamically increase the number of iterations.