### PR TITLE
resolves #248 and resolves #246

### DIFF
--- a/app/styles/components/elvis-data-table.scss
+++ b/app/styles/components/elvis-data-table.scss
@@ -8,7 +8,7 @@
     width: 100%;
     height: calc(100vh - 250px);
     position: relative;
-    table-layout: fixed;
+    display: block;
 
     thead { display: none; }
     td {


### PR DESCRIPTION
two issues, same description :D

problem was that the scrollbar <div> appends directly inside <table>. and { height: 100% } on table doesnt work same as on block. so i restyled: table.data-table { display: block; }
seems to work well now in firefox and others