### PR TITLE
Fix/network entity class names

### DIFF
--- a/app/styles/components/elvis-data-table.scss
+++ b/app/styles/components/elvis-data-table.scss
@@ -8,7 +8,7 @@
     width: 100%;
     height: calc(100vh - 250px);
     position: relative;
-    table-layout: fixed;
+    display: block;
 
     thead { display: none; }
     td {

--- a/app/styles/general/network.scss
+++ b/app/styles/general/network.scss
@@ -27,17 +27,17 @@
   background: $text-color;
   vertical-align: middle;
 }
-.procurer,
-.supplier {
+.figure-procurer,
+.figure-supplier {
   @include network-entity(1em);
 }
-.procurer {
+.figure-procurer {
   background: $color-procurer;
 }
-.supplier {
+.figure-supplier {
   background: $color-supplier;
 }
-.relationship {
+.figure-relationship {
   position: relative;
   top: .25em;
   z-index: 0;

--- a/app/styles/general/typography.scss
+++ b/app/styles/general/typography.scss
@@ -49,7 +49,8 @@ h5 {
 }
 h6 {
   font-size: $h6-fontsize;
-  opacity: .5;
+  line-height: 1.4;
+  opacity: .6;
   font-style: italic;
   text-transform: lowercase;
   letter-spacing: .05em;

--- a/app/templates/components/elvis-data-table.hbs
+++ b/app/templates/components/elvis-data-table.hbs
@@ -46,8 +46,8 @@
                 {{!-- relationships --}}
                 {{#if row.toLabel}}
                   {{#link-to "network.show.details.show" route row.link}}
-                    <small class="item-entity"><span class="procurer"></span>&nbsp;{{row.toLabel}}</small><br>
-                    <small class="item-entity"><span class="supplier"></span>&nbsp;{{row.fromLabel}}</small>
+                    <small class="item-entity"><span class="figure-procurer"></span>&nbsp;{{row.toLabel}}</small><br>
+                    <small class="item-entity"><span class="figure-supplier"></span>&nbsp;{{row.fromLabel}}</small>
                   {{/link-to}}
                 {{/if}}
                 {{!-- procurers / suppliers --}}

--- a/app/templates/network/show/details.hbs
+++ b/app/templates/network/show/details.hbs
@@ -65,19 +65,19 @@
       <div class="tabs__nav">
         {{#tab-button class="tab-button"  manager=sidebarTabManager name="suppliers"}}
         <a>
-          <span class="tab-icon supplier"></span>
+          <span class="tab-icon figure-supplier"></span>
           Suppliers
         </a>
         {{/tab-button}}
           {{#tab-button class="tab-button"  manager=sidebarTabManager  name="procurers"}}
           <a>
-            <span class="tab-icon procurer"></span>
+            <span class="tab-icon figure-procurer"></span>
             Procurers
           </a>
         {{/tab-button}}
         {{#tab-button class="tab-button"  manager=sidebarTabManager name="relationships" active-class="tabs-button--active2"}}
           <a>
-            <span class="tab-icon relationship"></span>
+            <span class="tab-icon figure-relationship"></span>
             Relationships
           </a>
         {{/tab-button}}

--- a/app/templates/partials/static/examples.hbs
+++ b/app/templates/partials/static/examples.hbs
@@ -51,21 +51,24 @@
 
 		    <h2>Network elements</h2>
 		    <hr>
-		    <p>We have simple components for displaying network elements. Just use <code>.procurer</code>, <code>.supplier</code> or <code>.relationship</code> classes on any element.</p>
-		    <p>They work inline: <span class="procurer"></span> + <span class="supplier"></span> = <span class="relationship"></span></p>
+		    <p>We have simple components for displaying network elements. Just use <code>.figure-procurer</code>, <code>.figure-supplier</code> or <code>.figure-relationship</code> classes on any element.</p>
+		    <p>They work inline: <span class="figure-procurer"></span> + <span class="figure-supplier"></span> = <span class="figure-relationship"></span></p>
 		    <p>Or in block:</p>
         <div class="row">
 		      <div class="col s4 center">
-						    <div class="procurer"></div>
-                <h5>.procurer</h5>
+						    <div class="figure-procurer"></div>
+                <br>
+                <code>.figure-procurer</code>
 				    </div>
             <div class="col s4 center">
-                <div class="supplier"></div>
-                <h5>.supplier</h5>
+                <div class="figure-supplier"></div>
+                <br>
+                <code>.figure-supplier</code>
             </div>
             <div class="col s4 center">
-                <div class="relationship"></div>
-                <h5>.relationship</h5>
+                <div class="figure-relationship"></div>
+	              <br>
+                <code>.figure-relationship</code>
             </div>
 		    </div>
 

--- a/app/templates/welcome.hbs
+++ b/app/templates/welcome.hbs
@@ -27,35 +27,27 @@
       <div class="node-types">
         <div class="row">
           <div class="col s4 center-align">
-            <div class="relative circle-img">
-              <span class="absolute circle procurer"> {{fa-icon 'circle' size=2}} </span>
-            </div>
-            <div class="el-label">
+            <div class="figure-procurer"></div>
+            <h4 class="el-label">
               Procurer Nodes
-            </div>
-            <div class="description italic grey-text">
+            </h4>
+            <h6>
               goverment institutions <br> lorem impsum <br> dolor sit amet
-            </div>
+            </h6>
           </div>
           <div class="col s4 center-align">
-            <div class="relative circle-img">
-              <span class="absolute circle supplier"> {{fa-icon 'circle' size=2}} </span>
-            </div>
-            <div class="el-label">Supplier Nodes</div>
-            <div class="description italic">
+            <div class="figure-supplier"></div>
+            <h4 class="el-label">Supplier Nodes</h4>
+            <h6>
               suspicious companies <br> favorite goverment contractors <br> lorem impsum
-            </div>
+            </h6>
           </div>
           <div class="col s4 center-align">
-            <div class="relative circle-img">
-              <span class="absolute circle relationship-line"> <hr/> </span>
-              <span class="absolute circle relationship rel1"> {{fa-icon 'circle' size=2}} </span>
-              <span class="absolute circle relationship rel2"> {{fa-icon 'circle' size=2}} </span>
-            </div>
-            <div class="el-label">Relationships</div>
-            <div class="description italic">
+            <div class="figure-relationship"></div>
+            <h4 class="el-label">Relationships</h4>
+            <h6>
               money flow <br>  amount of contracts  <br> lorem impsum
-            </div>
+            </h6>
 
           </div>
         </div>


### PR DESCRIPTION
i have fixed problems which came with new html components for network entities: `.procurer`, `.supplier` and `.relationship` has been given class prefix `figure-*` so they do not interfere with @ca1yps0 's class names. 

i would also suggest that for the future, in general, instead of .procurer, .supplier and .relationship we use more context-specific class names for these entities by giving them prefix