### PR TITLE
fix: node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "repository": "https://github.com/tenders-exposed/elvis-ember.git",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "^8.15"
   },
   "devDependencies": {
     "@commitlint/cli": "^7.5.2",


### PR DESCRIPTION
Fix builds by pinning down the only (?) node version we know it's working properly with our code.